### PR TITLE
Internal Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Seafile Server Docker image
 [Seafile](http://seafile.com/) server Docker image based on [Alpine Linux](https://hub.docker.com/_/alpine/).
 
-Also in my [Github repository](https://github.com/VGoshev/seafile-docker) you can find some usefull scripts for helping running containers.
+Also in my [Github repository](https://github.com/VGoshev/seafile-docker) you can find some useful scripts for helping running containers.
 
 ## Supported tags and respective `Dockerfile` links
 
@@ -13,37 +13,36 @@ Dockerfiles for older versions of Seafile Server you can find [there](https://gi
 
 To run container you can use following command:
 ```bash
-docker run \  
-  -v /home/docker/seafile:/home/seafile \  
-  -p 127.0.0.1:8000:8000 \  
-  -p 127.0.0.1:8082:8082 \  
-  -ti sunx/seafile`
+docker run \
+  -v /home/docker/seafile:/home/seafile \
+  -p 127.0.0.1:8000:8000 \
+  -p 127.0.0.1:8082:8082 \
+  -ti sunx/seafile
 ```
-Containers, based on this image will automatically configure 
- Seafile enviroment if there isn't any. If Seafile enviroment is from previous version of Seafile, container will automatically upgrade it to latest version (by calling Seafile upgrade scripts).
- 
-But I would advise you to do data backups before upgrading image 
- (to not lose your data in case of bugs in upgrade logic of this image or Seafile upgrde scripts).
+Containers, based on this image will automatically configure
+ Seafile environment if there isn't any. If Seafile environment is from previous version of Seafile, container will automatically upgrade it to latest version (by calling Seafile upgrade scripts).
+
+But I would advise you to do data backups before upgrading image
+ (to not lose your data in case of bugs in upgrade logic of this image or Seafile upgrade scripts).
 
 ## Detailed description of image and containers
 
 ### Used ports
 
-This image uses 2 tcp ports:
-* 8000 - seafile port
-* 8082 - seahub port
+This image uses 2 TCP ports:
+* 8000 - Seafile port
+* 8082 - Seahub port
 
 If you want to run seafdav (WebDAV for Seafile), then port 8080 will be used also.
 
 ### Volume
-This image uses one volume with internal path `/home/seafile`
+This image uses one volume with internal path `/home/seafile`.
 
-I would recommend you use host directory mapping of named volume to run containers, so you will not lose your valuable data after image update and starting new container
+I would recommend you use host directory mapping of named volume to run containers, so you will not lose your valuable data after image update and starting new container.
 
 ### Web server configuration
 
-This image doesnt contain any web-servers, because you, usually, already have some http server running on your server and don't want to run any extra http-servers (because it will cost you some CPU time and Memory). But if you know some really tiny web-server with proxying support, tell me and I would be glad to integrate it to the image.
-
+This image doesn't contain any web-servers, because you, usually, already have some http server running on your server and don't want to run any extra http-servers (because it will cost you some CPU time and Memory). But if you know some really tiny web-server with proxying support, tell me and I would be glad to integrate it to the image.
 
 For Web-server configuration, as media directory location you should enter
 `<volume/path>/seafile-server/seahub/media`
@@ -52,48 +51,48 @@ In [httpd-conf](https://github.com/VGoshev/seafile-docker/blob/master/httpd-conf
 [lighttpd](https://www.lighttpd.net/) [config example](https://github.com/VGoshev/seafile-docker/blob/master/httpd-conf/lighttpd.conf.example) and
 [haaproxy](https://www.haproxy.com/) [config example](https://github.com/VGoshev/seafile-docker/blob/master/httpd-conf/haproxy.cfg).
 
-You can find 
-[Nginx](https://manual.seafile.com/deploy/deploy_with_nginx.html) and 
-[Apache](https://manual.seafile.com/deploy/deploy_with_apache.html) 
+You can find
+[Nginx](https://manual.seafile.com/deploy/deploy_with_nginx.html) and
+[Apache](https://manual.seafile.com/deploy/deploy_with_apache.html)
 configurations in official Seafile Server [Manual](https://manual.seafile.com/).
 
 ### Supported ENV variables
 
-When you running container, you can pass several enviroment variables (with **--env** option of **docker run** command):
+When you running container, you can pass several environment variables (with **--env** option of **docker run** command):
 * **`INTERACTIVE`**=\<0|1> - if container should ask you about some configuration values (on first run) and about upgrades. Default: 1
 * **`SERVER_NAME`**=\<...> - Name of Seafile server (3 - 15 letters or digits), used only for first run in non-interactive mode. Default: Seafile
-* **`SERVER_DOMAIN`**=\<...> - Domain or ip of seafile server, used only for first run in non-interactive mode. Default: seafile.domain.com
-* **`SEAHUB`**=\<fastcgi> - If seahub should be started in FastCGI mode (set it "fastcgi" for FastCGI mode or leave empty otherwise). Default: empty (not FastCGI mode).
-* **`SEAFILE_FASTCGI_HOST`**=\<ip> - Binding ip for seahub in FastCGI mode. Default: 127.0.0.1.
+* **`SERVER_DOMAIN`**=\<...> - Domain or IP of seafile server, used only for first run in non-interactive mode. Default: seafile.domain.com
+* **`SEAHUB`**=\<fastcgi> - If Seahub should be started in FastCGI mode (set it "fastcgi" for FastCGI mode or leave empty otherwise). Default: empty (not FastCGI mode).
+* **`SEAFILE_FASTCGI_HOST`**=\<IP> - Binding IP for Seahub in FastCGI mode. Default: 127.0.0.1.
 * **`HANDLE_SIGNALS`**=\<0|1> - If container should properly handle signals like SIGHUP and SIGTERM (SIGTERM is sending on `docker stop` command, for example). If signals handling is turned on, then script will run infinity cycle for waiting signal, what, in theory, could slightly increase CPU consumption by container. Default: 1 (i.e. Turned on).
 
 ## Useful commands in container
 
-When you're inside of container, in home directory of seafile user, you can use following useful commands:
+When you're inside of container, in home directory of Seafile user, you can use following useful commands:
 * `seafile-fsck` - check your libraries for errors (Originally seaf-fsck.sh is used for it)
-* `seafile-gc` - remove ald unused data from storage of your seafile libraries (Originally seaf-gc.sh is used for it)
-* `seafile-admin start` - start seafile and seahub daemons (if they were stopped)
-* `seafile-admin stop` - stop seafile and seahub daemons
-* `seafile-admin reset-admin` - reset seafile admin user and/or password
-* `seafile-admin setup` - setup ccnet, seafile and seahub services (if they wasn't configured automatically by some reason)
-* `seafile-admin create-admin` - create seafile admin user (if it wasn't created automatically by some reason)
+* `seafile-gc` - remove old unused data from storage of your Seafile libraries (Originally seaf-gc.sh is used for it)
+* `seafile-admin start` - start Seafile and Seahub daemons (if they were stopped)
+* `seafile-admin stop` - stop Seafile and Seahub daemons
+* `seafile-admin reset-admin` - reset Seafile admin user and/or password
+* `seafile-admin setup` - setup ccnet, Seafile and Seahub services (if they wasn't configured automatically by some reason)
+* `seafile-admin create-admin` - create Seafile admin user (if it wasn't created automatically by some reason)
 
 ## Tips&amp;Tricks and Known issues
 
-* Make sure, that mounted data volume and files are radable and writable by container's seafile user(2016:2016).
+* Make sure, that mounted data volume and files are readable and writable by container's seafile user(2016:2016).
 
 * If you want to run seafdav, which is disabled by default, you can read it's [manual](https://manual.seafile.com/extension/webdav.html). Do not forget to publish port 8080 after it.
 
-* If you do not want container to automatically upgrade your Seafile enviroment on image (and Seafile-server) update, 
-you can add empty file named `.no-update` to directory `/home/seafile` in your container. You can use **`docker exec <container_name> touch /home/seafile/.no-update`** for it.
+* If you do not want container to automatically upgrade your Seafile environment on image (and Seafile-server) update,
+you can add empty file named `.no-update` to directory `/home/seafile` in your container. You can use `docker exec <container_name> touch /home/seafile/.no-update` for it.
 
-* Container uses seafile user to run seafile, so if you need to do something with root access in container, you can use **`docker exec -ti --user=0 <container_name> /bin/sh`** for it.
+* Container uses Seafile user to run Seafile, so if you need to do something with root access in container, you can use `docker exec -ti --user=0 <container_name> /bin/sh` for it.
 
 * On first run (end every image upgrade) container will copy seahub directory from `/usr/local/share/seahub` to `/home/seafile/seafile-server/seahub `(i.e. to the volume), so it cost about 40Mb of space. I'm not sure if it could be changed without using webserver inside of container (But 40Mb of space isn't to much in our days, I think).
 
-* At this moment most seafile scripts (which are located in `/usr/local/share/seafile/scripts` directory) aren't working properly, but I do not think that they are to usefull for this image (scripts `seaf-fsck.sh` and `seaf-gc.sh` are working correctly and also avaliable as `/usr/local/bin/seafile-fsck` and `/usr/local/bin/seafile-gc`).
+* At this moment most Seafile scripts (which are located in `/usr/local/share/seafile/scripts` directory) aren't working properly, but I do not think that they are to useful for this image (scripts `seaf-fsck.sh` and `seaf-gc.sh` are working correctly and also available as `/usr/local/bin/seafile-fsck` and `/usr/local/bin/seafile-gc`).
 
-* This image confugure sqlite-based Seafile server installation. If you want to run Seafile server witn MySQL\MariaDB, then you can configure it manually, or say to me about it and I'll add such configuration option.
+* This image configures SQLite-based Seafile server installation. If you want to run Seafile server with MySQL/MariaDB, then you can configure it manually, or ask me about it and I'll add such configuration option.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ When you running container, you can pass several environment variables (with `--
   <dd>If Seahub should be started in FastCGI mode (set it "fastcgi" for FastCGI mode or leave empty otherwise). Default: <code>empty</code> (not FastCGI mode).</dd>
   <dt><code>SEAFILE_FASTCGI_HOST=<IP></code></dt>
   <dd>Binding IP for Seahub in FastCGI mode. Default: <code>127.0.0.1</code></dd>
-  <dt><code>HANDLE_SIGNALS=<0|1></code></dt>
-  <dd>If container should properly handle signals like SIGHUP and SIGTERM (SIGTERM is sending on <code>docker stop</code> command, for example). If signals handling is turned on, then script will run infinity cycle for waiting signal, what, in theory, could slightly increase CPU consumption by container. Default: <code>1</code> (i.e. Turned on)</dd>
 </dl>
 
 ## Useful commands in container

--- a/README.md
+++ b/README.md
@@ -58,13 +58,22 @@ configurations in official Seafile Server [Manual](https://manual.seafile.com/).
 
 ### Supported ENV variables
 
-When you running container, you can pass several environment variables (with **--env** option of **docker run** command):
-* **`INTERACTIVE`**=\<0|1> - if container should ask you about some configuration values (on first run) and about upgrades. Default: 1
-* **`SERVER_NAME`**=\<...> - Name of Seafile server (3 - 15 letters or digits), used only for first run in non-interactive mode. Default: Seafile
-* **`SERVER_DOMAIN`**=\<...> - Domain or IP of seafile server, used only for first run in non-interactive mode. Default: seafile.domain.com
-* **`SEAHUB`**=\<fastcgi> - If Seahub should be started in FastCGI mode (set it "fastcgi" for FastCGI mode or leave empty otherwise). Default: empty (not FastCGI mode).
-* **`SEAFILE_FASTCGI_HOST`**=\<IP> - Binding IP for Seahub in FastCGI mode. Default: 127.0.0.1.
-* **`HANDLE_SIGNALS`**=\<0|1> - If container should properly handle signals like SIGHUP and SIGTERM (SIGTERM is sending on `docker stop` command, for example). If signals handling is turned on, then script will run infinity cycle for waiting signal, what, in theory, could slightly increase CPU consumption by container. Default: 1 (i.e. Turned on).
+When you running container, you can pass several environment variables (with `--env` option of `docker run` command):
+
+<dl>
+  <dt><code>INTERACTIVE=<0|1></code></dt>
+  <dd>if container should ask you about some configuration values (on first run) and about upgrades. Default: <code>1</code></dd>
+  <dt><code>SERVER_NAME=<name></code></dt>
+  <dd>Name of Seafile server (3 - 15 letters or digits), used only for first run in non-interactive mode. Default: <code>Seafile</code></dd>
+  <dt><code>SERVER_DOMAIN=<domain|IP></code></dt>
+  <dd>Domain or IP of seafile server, used only for first run in non-interactive mode. Default: <code>seafile.domain.com</code></dd>
+  <dt><code>SEAHUB</code></dt>
+  <dd>If Seahub should be started in FastCGI mode (set it "fastcgi" for FastCGI mode or leave empty otherwise). Default: <code>empty</code> (not FastCGI mode).</dd>
+  <dt><code>SEAFILE_FASTCGI_HOST=<IP></code></dt>
+  <dd>Binding IP for Seahub in FastCGI mode. Default: <code>127.0.0.1</code></dd>
+  <dt><code>HANDLE_SIGNALS=<0|1></code></dt>
+  <dd>If container should properly handle signals like SIGHUP and SIGTERM (SIGTERM is sending on <code>docker stop</code> command, for example). If signals handling is turned on, then script will run infinity cycle for waiting signal, what, in theory, could slightly increase CPU consumption by container. Default: <code>1</code> (i.e. Turned on)</dd>
+</dl>
 
 ## Useful commands in container
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -10,7 +10,6 @@ if `echo $ARCH | grep -q arm`; then
 	sed -r 's,(FROM)\s+(alpine),\1 armhf/\2,' < ./docker/Dockerfile > ./docker/Dockerfile.arm
 
 	docker build -t $IMAGE -f ./docker/Dockerfile.arm ./docker/
-	#&& rm -rf ./build
 else
 	if `echo $ARCH | grep -q x86_64`; then
 		docker build -t $IMAGE ./docker/

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-cd `dirname $0`
+cd $(dirname $0)
 
-ARCH=`uname -m`
+ARCH=$(uname -m)
 IMAGE="sunx/seafile"
 
 if echo $ARCH | grep -q arm; then

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -5,13 +5,13 @@ cd `dirname $0`
 ARCH=`uname -m`
 IMAGE="sunx/seafile"
 
-if `echo $ARCH | grep -q arm`; then
+if echo $ARCH | grep -q arm; then
 	#Use armhf/alpine as base image instead of alpine
 	sed -r 's,(FROM)\s+(alpine),\1 armhf/\2,' < ./docker/Dockerfile > ./docker/Dockerfile.arm
 
 	docker build -t $IMAGE -f ./docker/Dockerfile.arm ./docker/
 else
-	if `echo $ARCH | grep -q x86_64`; then
+	if echo $ARCH | grep -q x86_64; then
 		docker build -t $IMAGE ./docker/
 	else 
 		echo "Error: Architecture $ARCH isn't supported"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       # Start seahub in FastCGI mode
       SEAHUB: fastcgi
       SEAFILE_FASTCGI_HOST: 0.0.0.0
-      HANDLE_SIGNALS: 1
 #      DEBUG: 1
 
     container_name: seafile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
 
     environment:
       # Start seahub in FastCGI mode
-      SEAHUB: fastcgi
-      SEAFILE_FASTCGI_HOST: 0.0.0.0
-#      DEBUG: 1
+      - SEAHUB=fastcgi
+      - SEAFILE_FASTCGI_HOST=0.0.0.0
+#     - DEBUG=1
 
     container_name: seafile
 #    domainname: seafile.domain.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: sunx/seafile
     build:
       context: ./docker
-    
+
     volumes:
       - /home/docker/seafile:/home/seafile:rw
     ports:
@@ -19,8 +19,7 @@ services:
       SEAFILE_FASTCGI_HOST: 0.0.0.0
       HANDLE_SIGNALS: 1
 #      DEBUG: 1
-    
-    
+
     container_name: seafile
 #    domainname: seafile.domain.com
     restart: unless-stopped

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,10 +8,10 @@ MAINTAINER Vladimir Goshev <sunx@sunx.name>
 #
 # SEAFILE_VERSION:
 # Seafile-Server version do townload and install
-#  See https://github.com/haiwen/seafile-server/releases 
+#  See https://github.com/haiwen/seafile-server/releases
 #  for latest avaliable version
-# uUID - set UID of seafile user, default: 2016
-# uGID - set GID of seafile user, default: 2016
+# uUID - set UID of Seafile user, default: 2016
+# uGID - set GID of Seafile user, default: 2016
 ENV SEAFILE_SERVER_DIR="/home/seafile" \
 	SEAFILE_VERSION="6.2.2"
 
@@ -31,6 +31,6 @@ VOLUME $SEAFILE_SERVER_DIR
 
 USER seafile
 
-# Container will run /bin/docker-run with seafile user access 
+# Container will run /bin/docker-run with Seafile user access
 # to configure (if needed) and run Seafile server
 CMD ["/bin/docker-run"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,35 @@ RUN apk add --update \
 # Most of installation stuff is done in build.sh
 COPY build.sh /tmp/build.sh
 COPY seafile-server.patch /tmp/seafile-server.patch
-# Execute our build script and delete it because we won't need it anymore
-RUN /tmp/build.sh "$SEAFILE_VERSION" "$SEAFILE_SERVER_DIR" && rm /tmp/build.sh
+# Add build-deps for Seafile-Server
+RUN apk add --update --virtual .build_dep \
+        autoconf \
+        automake \
+        bsd-compat-headers \
+        cmake \
+        curl-dev \
+        file \
+        fuse-dev \
+        g++ \
+        gcc \
+        git \
+        glib-dev \
+        intltool \
+        jansson-dev \
+        libarchive-dev \
+        libevent-dev \
+        libtool \
+        make \
+        mariadb-dev \
+        musl-dev \
+        py-pip \
+        python-dev \
+        sqlite-dev \
+        util-linux-dev \
+        vala \
+# Run the buildscript and remove builddep packages again
+ && /tmp/build.sh "$SEAFILE_VERSION" "$SEAFILE_SERVER_DIR" \
+ && apk del --purge .build_dep
 
 # Container initialization scripts ()
 COPY docker-run.sh /bin/docker-run

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,7 @@ RUN apk add --update --virtual .build_dep \
         sqlite-dev \
         util-linux-dev \
         vala \
+        wget \
 # Run the buildscript and remove builddep packages again
  && /tmp/build.sh \
  && apk del --purge .build_dep

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,7 @@ RUN apk add --update --virtual .build_dep \
         util-linux-dev \
         vala \
 # Run the buildscript and remove builddep packages again
- && /tmp/build.sh "$SEAFILE_VERSION" "$SEAFILE_SERVER_DIR" \
+ && /tmp/build.sh \
  && apk del --purge .build_dep
 
 # Container initialization scripts ()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,13 +70,11 @@ RUN apk add --update --virtual .build_dep \
  && apk del --purge .build_dep
 
 # Container initialization scripts ()
-COPY docker-run.sh /bin/docker-run
+COPY docker-run.sh /usr/local/bin/docker-run
 
 EXPOSE 8000 8082
 VOLUME $SEAFILE_SERVER_DIR
 
 USER seafile
 
-# Container will run /bin/docker-run with Seafile user access
-# to configure (if needed) and run Seafile server
-CMD ["/bin/docker-run"]
+CMD ["/usr/local/bin/docker-run"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,28 @@ MAINTAINER Vladimir Goshev <sunx@sunx.name>
 ENV SEAFILE_SERVER_DIR="/home/seafile" \
 	SEAFILE_VERSION="6.2.2"
 
-# All installation proccess is in build.sh
-# It is possible to do all work via RUN command(s)
-# But it looks much better with all work in script
+###########################################
+# Runtime dependencies for Seafile-Server #
+# bash is needed for upgrade scripts      #
+###########################################
+RUN apk add --update \
+        bash \
+        glib \
+        jansson \
+        libarchive \
+        libevent \
+        mariadb-client-libs \
+        openssl \
+        postgresql-libs \
+        py-imaging \
+        py-pillow \
+        py-setuptools \
+        python \
+        sqlite \
+        util-linux \
+ && rm -rf /var/cache/apk/*
+
+# Most of installation stuff is done in build.sh
 COPY build.sh /tmp/build.sh
 COPY seafile-server.patch /tmp/seafile-server.patch
 # Execute our build script and delete it because we won't need it anymore

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -54,37 +54,6 @@ cd $WORK_DIR
 [ -z "$uUID" ] && uUID=2016
 [ -z "$uGID" ] && uGID=2016
 
-
-
-#################################################
-# Add build-deps for Seafile-Server             #
-#################################################
-apk add --virtual .build_dep \
-        autoconf \
-        automake \
-        bsd-compat-headers \
-        cmake \
-        curl-dev \
-        file \
-        fuse-dev \
-        g++ \
-        gcc \
-        git \
-        glib-dev \
-        intltool \
-        jansson-dev \
-        libarchive-dev \
-        libevent-dev \
-        libtool \
-        make \
-        mariadb-dev \
-        musl-dev \
-        py-pip \
-        python-dev \
-        sqlite-dev \
-        util-linux-dev \
-        vala \
-
 PYTHON_PACKAGES_DIR=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
 
 ####################
@@ -214,7 +183,6 @@ echo "Seafile user has been created and configured successfully!"
 # Delete all unneeded files and packages #
 ##########################################
 cd /
-apk del --purge .build_dep
 rm -rf $WORK_DIR
 rm /var/cache/apk/*
 rm -rf /root/.cache

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -35,7 +35,7 @@ fi
 
 ##########################################
 # Use latest, buggy things in our image. #
-# Like seahub via symlink.               #
+# Like Seahub via symlink.               #
 ##########################################
 EDGE_V=0
 if [ "x$3" = "x1" ]; then
@@ -51,7 +51,7 @@ mkdir -p $WORK_DIR
 cd $WORK_DIR
 
 ################################
-# UID and GID for seafile user #
+# UID and GID for Seafile user #
 ################################
 [ -z "$uUID" ] && uUID=2016
 [ -z "$uGID" ] && uGID=2016
@@ -143,21 +143,21 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ###########################
 cd $WORK_DIR/ccnet-server-${SEAFILE_VERSION}-server/ && \
 	./autogen.sh && \
-    ./configure --with-mysql --with-postgresql --enable-python && \
-		make && make install
+	./configure --with-mysql --with-postgresql --enable-python && \
+	make && make install
 
 
 ####################################
 # Build and install Seafile-Server #
 # As a First step we need to patch #
-# seafile-controller topdir        #
+# Seafile-controller topdir        #
 # And some scripts                 #
 ####################################
 cd $WORK_DIR/seafile-server-${SEAFILE_VERSION}-server/
 patch -p1 < /tmp/seafile-server.patch
 ./autogen.sh && \
-    ./configure --with-mysql --with-postgresql --enable-python && \
-		make && make install
+	./configure --with-mysql --with-postgresql --enable-python && \
+	make && make install
 
 #Copy some useful scripts to /usr/local/bin
 #mkdir -p /usr/local/bin
@@ -187,26 +187,26 @@ echo "Seafile-Server has been built successfully!"
 
 ##############################
 # Do some preparations       #
-# Like add seafile user and  #
+# Like add Seafile user and  #
 #  create his home directory #
 ##############################
 
 addgroup -g "$uGID" seafile
 adduser -D -s /bin/sh -g "Seafile Server" -G seafile -h "$SEAFILE_SERVER_DIR" -u "$uUID" seafile
 
-# Create seafile-server dir 
+# Create Seafile-server dir 
 su - -c "mkdir ${SEAFILE_SERVER_DIR}/seafile-server" seafile
 
-# Store seafile version and if tis is edge image
+# Store Seafile version and if tis is edge image
 mkdir -p /var/lib/seafile
 echo -n "$SEAFILE_VERSION" > /var/lib/seafile/version
 echo -n "$EDGE_V" > /var/lib/seafile/edge
 
-echo "seafile user has been created and configured successfully!"
+echo "Seafile user has been created and configured successfully!"
 
-#########################################
-# Delete all unneded files and packages #
-#########################################
+##########################################
+# Delete all unneeded files and packages #
+##########################################
 cd /
 apk del --purge .build_dep
 rm -rf $WORK_DIR
@@ -214,7 +214,7 @@ rm /var/cache/apk/*
 rm -rf /root/.cache
 rm -f /tmp/seafile-server.patch
 
-echo "unneded files were cleaned"
+echo "Unneeded files were cleaned"
 
 echo "Done!"
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -63,19 +63,50 @@ apk update
 # Runtime dependencies for Seafile-Server #
 # bash is needed for upgrade scripts      #
 ###########################################
-apk add bash openssl python py-setuptools py-imaging sqlite \
-    libevent util-linux glib jansson libarchive \
-		mariadb-client-libs postgresql-libs py-pillow
+apk add \
+        bash \
+        glib \
+        jansson \
+        libarchive \
+        libevent \
+        mariadb-client-libs \
+        openssl \
+        postgresql-libs \
+        py-imaging \
+        py-pillow \
+        py-setuptools \
+        python \
+        sqlite \
+        util-linux \
 
 #################################################
 # Add build-deps for Seafile-Server             #
 #################################################
 apk add --virtual .build_dep \
-    curl-dev libevent-dev glib-dev util-linux-dev intltool \
-    sqlite-dev libarchive-dev libtool jansson-dev vala fuse-dev \
-    cmake make musl-dev gcc g++ automake autoconf bsd-compat-headers \
-    python-dev file mariadb-dev mariadb-dev py-pip git
-
+        autoconf \
+        automake \
+        bsd-compat-headers \
+        cmake \
+        curl-dev \
+        file \
+        fuse-dev \
+        g++ \
+        gcc \
+        git \
+        glib-dev \
+        intltool \
+        jansson-dev \
+        libarchive-dev \
+        libevent-dev \
+        libtool \
+        make \
+        mariadb-dev \
+        musl-dev \
+        py-pip \
+        python-dev \
+        sqlite-dev \
+        util-linux-dev \
+        vala \
 
 PYTHON_PACKAGES_DIR=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -27,7 +27,7 @@ cd $WORK_DIR
 [ -z "$uUID" ] && uUID=2016
 [ -z "$uGID" ] && uGID=2016
 
-PYTHON_PACKAGES_DIR=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
+PYTHON_PACKAGES_DIR=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 ####################
 # Install libevhtp #

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -32,7 +32,7 @@ PYTHON_PACKAGES_DIR=$(python -c "from distutils.sysconfig import get_python_lib;
 ####################
 # Install libevhtp #
 ####################
-wget https://github.com/haiwen/libevhtp/archive/${LIBEVHTP_VERSION}.tar.gz -O- | tar xzf -
+wget -nv https://github.com/haiwen/libevhtp/archive/${LIBEVHTP_VERSION}.tar.gz -O- | tar xzf -
 cd libevhtp-${LIBEVHTP_VERSION}/
 cmake -DEVHTP_DISABLE_SSL=ON -DEVHTP_BUILD_SHARED=ON .
 make
@@ -43,12 +43,12 @@ cp oniguruma/onigposix.h /usr/include/
 # Download all Seafile components #
 ###################################
 cd $WORK_DIR
-wget https://github.com/haiwen/libsearpc/archive/v${LIBSEARPC_VERSION}.tar.gz -O- | tar xzf -
-wget https://github.com/haiwen/ccnet-server/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
-wget https://github.com/haiwen/seafile-server/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
-wget https://github.com/haiwen/seahub/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
-wget https://github.com/haiwen/seafobj/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
-wget https://github.com/haiwen/seafdav/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
+wget -nv https://github.com/haiwen/libsearpc/archive/v${LIBSEARPC_VERSION}.tar.gz -O- | tar xzf -
+wget -nv https://github.com/haiwen/ccnet-server/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
+wget -nv https://github.com/haiwen/seafile-server/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
+wget -nv https://github.com/haiwen/seahub/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
+wget -nv https://github.com/haiwen/seafobj/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
+wget -nv https://github.com/haiwen/seafdav/archive/v${SEAFILE_VERSION}-server.tar.gz -O- | tar xzf -
 
 #####################################
 # Seahub is python application,     #

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -11,24 +11,8 @@ ln -s /etc/profile.d/color_prompt /etc/profile.d/color_prompt.sh
 # The PATH-variable depends on the host's setting. /usr/local/bin may not be included in every distro
 export PATH="${PATH}:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 
-######################################
-# Get Seafile Version from first arg #
-#  (or use 6.0.5 as default)         #
-######################################
-SEAFILE_VERSION="6.0.10"
-if [ "x$1" != "x" ]; then
-    SEAFILE_VERSION=$1
-fi
-
 [ -z $LIBEVHTP_VERSION  ] && LIBEVHTP_VERSION="18c649203f009ef1d77d6f8301eba09af3777adf"
 [ -z $LIBSEARPC_VERSION ] && LIBSEARPC_VERSION="3.1-latest"
-##################################
-# Where we should install Seahub #
-##################################
-SEAFILE_SERVER_DIR="/home/seafile"
-if [ "x$2" != "x" ]; then
-    SEAFILE_SERVER_DIR=$2
-fi
 
 ##########################################
 # Use latest, buggy things in our image. #

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -55,29 +55,6 @@ cd $WORK_DIR
 [ -z "$uGID" ] && uGID=2016
 
 
-################################
-# Install some needed packages #
-################################
-apk update
-###########################################
-# Runtime dependencies for Seafile-Server #
-# bash is needed for upgrade scripts      #
-###########################################
-apk add \
-        bash \
-        glib \
-        jansson \
-        libarchive \
-        libevent \
-        mariadb-client-libs \
-        openssl \
-        postgresql-libs \
-        py-imaging \
-        py-pillow \
-        py-setuptools \
-        python \
-        sqlite \
-        util-linux \
 
 #################################################
 # Add build-deps for Seafile-Server             #

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -7,11 +7,9 @@ set -e
 # Fix little bug in alpine image
 ln -s /etc/profile.d/color_prompt /etc/profile.d/color_prompt.sh
 
-###################################################
-# We'll need binaries from different paths,       #
-#  so we should be sure, all bin dir in the PATH  #
-###################################################
-PATH="${PATH}:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+# Make sure, that /usr/local/bin is in PATH
+# The PATH-variable depends on the host's setting. /usr/local/bin may not be included in every distro
+export PATH="${PATH}:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 
 ######################################
 # Get Seafile Version from first arg #

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -20,7 +20,6 @@ if [ "x$1" != "x" ]; then
     SEAFILE_VERSION=$1
 fi
 
-#[ -z $LIBEVHTP_VERSION  ] && LIBEVHTP_VERSION="1.2.0"
 [ -z $LIBEVHTP_VERSION  ] && LIBEVHTP_VERSION="18c649203f009ef1d77d6f8301eba09af3777adf"
 [ -z $LIBSEARPC_VERSION ] && LIBSEARPC_VERSION="3.1-latest"
 ##################################
@@ -59,9 +58,7 @@ PYTHON_PACKAGES_DIR=`python -c "from distutils.sysconfig import get_python_lib; 
 ####################
 # Install libevhtp #
 ####################
-#wget https://github.com/ellzey/libevhtp/archive/${LIBEVHTP_VERSION}.tar.gz -O- | tar xzf -
 wget https://github.com/haiwen/libevhtp/archive/${LIBEVHTP_VERSION}.tar.gz -O- | tar xzf -
-#https://github.com/haiwen/libevhtp/archive/18c649203f009ef1d77d6f8301eba09af3777adf.zip
 cd libevhtp-${LIBEVHTP_VERSION}/ && cmake -DEVHTP_DISABLE_SSL=ON -DEVHTP_BUILD_SHARED=ON . && make && make install && cp oniguruma/onigposix.h /usr/include/
 
 ###################################
@@ -97,13 +94,7 @@ index 0b40098..a569b94 100644
 " | patch -p1 && pip install -r requirements.txt
 
 pip install gunicorn flup django-picklefield requests
-#   django_compressor django-post_office \
-#   django==1.8 pytz django-statici18n djangorestframework \
-#   chardet python-dateutil six openpyxl
-#pip install https://github.com/haiwen/django-constance/archive/bde7f7c.zip
-#pip install https://github.com/haiwen/django-constance/archive/6b04a31.zip
 
-#mv $WORK_DIR/seahub-${SEAFILE_VERSION}-server/ /usr/local/share/seahub
 mkdir -p /usr/local/share/seafile
 tar czf /usr/local/share/seafile/seahub.tgz -C $WORK_DIR/seahub-${SEAFILE_VERSION}-server/ ./
 ###############################
@@ -135,11 +126,9 @@ patch -p1 < /tmp/seafile-server.patch
 	make && make install
 
 #Copy some useful scripts to /usr/local/bin
-#mkdir -p /usr/local/bin
 cp scripts/seaf-fsck.sh /usr/local/bin/seafile-fsck
 cp scripts/seaf-gc.sh /usr/local/bin/seafile-gc
 # Also copy scripts to save them
-#mkdir -p /usr/local/share/seafile/
 mv scripts /usr/local/share/seafile/
 
 ###########

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -56,7 +56,8 @@ wget https://github.com/haiwen/seafdav/archive/v${SEAFILE_VERSION}-server.tar.gz
 #####################################
 
 cd $WORK_DIR/seahub-${SEAFILE_VERSION}-server/
-echo "diff --git a/seahub/settings.py b/seahub/settings.py
+patch -p1 <<-EOP
+diff --git a/seahub/settings.py b/seahub/settings.py
 index 0b40098..a569b94 100644
 --- a/seahub/settings.py
 +++ b/seahub/settings.py
@@ -69,7 +70,7 @@ index 0b40098..a569b94 100644
 
  # Compress static files(css, js)
  COMPRESS_URL = MEDIA_URL
-" | patch -p1
+EOP
 pip install -r requirements.txt
 
 pip install gunicorn flup django-picklefield requests

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -14,16 +14,6 @@ export PATH="${PATH}:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbi
 [ -z $LIBEVHTP_VERSION  ] && LIBEVHTP_VERSION="18c649203f009ef1d77d6f8301eba09af3777adf"
 [ -z $LIBSEARPC_VERSION ] && LIBSEARPC_VERSION="3.1-latest"
 
-##########################################
-# Use latest, buggy things in our image. #
-# Like Seahub via symlink.               #
-##########################################
-EDGE_V=0
-if [ "x$3" = "x1" ]; then
-    EDGE_V=1
-fi
-
-
 ################################################################
 # We'll do all the work here. And delete whole directory after #
 ################################################################
@@ -155,10 +145,9 @@ adduser -D -s /bin/sh -g "Seafile Server" -G seafile -h "$SEAFILE_SERVER_DIR" -u
 # Create Seafile-server dir 
 su - -c "mkdir ${SEAFILE_SERVER_DIR}/seafile-server" seafile
 
-# Store Seafile version and if tis is edge image
+# Store Seafile version
 mkdir -p /var/lib/seafile
 echo -n "$SEAFILE_VERSION" > /var/lib/seafile/version
-echo -n "$EDGE_V" > /var/lib/seafile/edge
 
 echo "Seafile user has been created and configured successfully!"
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -43,7 +43,11 @@ PYTHON_PACKAGES_DIR=`python -c "from distutils.sysconfig import get_python_lib; 
 # Install libevhtp #
 ####################
 wget https://github.com/haiwen/libevhtp/archive/${LIBEVHTP_VERSION}.tar.gz -O- | tar xzf -
-cd libevhtp-${LIBEVHTP_VERSION}/ && cmake -DEVHTP_DISABLE_SSL=ON -DEVHTP_BUILD_SHARED=ON . && make && make install && cp oniguruma/onigposix.h /usr/include/
+cd libevhtp-${LIBEVHTP_VERSION}/
+cmake -DEVHTP_DISABLE_SSL=ON -DEVHTP_BUILD_SHARED=ON .
+make
+make install
+cp oniguruma/onigposix.h /usr/include/
 
 ###################################
 # Download all Seafile components #
@@ -61,7 +65,7 @@ wget https://github.com/haiwen/seafdav/archive/v${SEAFILE_VERSION}-server.tar.gz
 #  just copy it in proper directory #
 #####################################
 
-cd $WORK_DIR/seahub-${SEAFILE_VERSION}-server/ &&
+cd $WORK_DIR/seahub-${SEAFILE_VERSION}-server/
 echo "diff --git a/seahub/settings.py b/seahub/settings.py
 index 0b40098..a569b94 100644
 --- a/seahub/settings.py
@@ -75,7 +79,8 @@ index 0b40098..a569b94 100644
 
  # Compress static files(css, js)
  COMPRESS_URL = MEDIA_URL
-" | patch -p1 && pip install -r requirements.txt
+" | patch -p1
+pip install -r requirements.txt
 
 pip install gunicorn flup django-picklefield requests
 
@@ -84,18 +89,22 @@ tar czf /usr/local/share/seafile/seahub.tgz -C $WORK_DIR/seahub-${SEAFILE_VERSIO
 ###############################
 # Build and install libSeaRPC #
 ###############################
-cd $WORK_DIR/libsearpc-${LIBSEARPC_VERSION}/ && ./autogen.sh && ./configure && make && make install
+cd $WORK_DIR/libsearpc-${LIBSEARPC_VERSION}/
+./autogen.sh
+./configure
+make
+make install
 
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 ###########################
 # Build and install CCNET #
 ###########################
-cd $WORK_DIR/ccnet-server-${SEAFILE_VERSION}-server/ && \
-	./autogen.sh && \
-	./configure --with-mysql --with-postgresql --enable-python && \
-	make && make install
-
+cd $WORK_DIR/ccnet-server-${SEAFILE_VERSION}-server/
+./autogen.sh
+./configure --with-mysql --with-postgresql --enable-python
+make
+make install
 
 ####################################
 # Build and install Seafile-Server #
@@ -105,9 +114,10 @@ cd $WORK_DIR/ccnet-server-${SEAFILE_VERSION}-server/ && \
 ####################################
 cd $WORK_DIR/seafile-server-${SEAFILE_VERSION}-server/
 patch -p1 < /tmp/seafile-server.patch
-./autogen.sh && \
-	./configure --with-mysql --with-postgresql --enable-python && \
-	make && make install
+./autogen.sh
+./configure --with-mysql --with-postgresql --enable-python
+make
+make install
 
 #Copy some useful scripts to /usr/local/bin
 cp scripts/seaf-fsck.sh /usr/local/bin/seafile-fsck

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -56,13 +56,6 @@ stop_seafile() {
 	exit 0
 }
 
-kill_seafile() {
-	echo "SIGKILL received, killing Seafile..."
-	killall -9 seafile-controller
-	killall -9 $(cat ${HOME}/seafile-server/runtime/seahub.pid)
-	exit 0
-}
-
 hup_seafile() {
 	echo "SIGHUP or similar received, restarting Seafile..."
 	cd ${HOME}
@@ -242,7 +235,6 @@ echo "Starting seafile server..."
 start_seafile_server
 
 trap stop_seafile INT TERM PWR
-trap kill_seafile KILL
 trap hup_seafile HUP
 
 if [ $RESET_ADMIN -eq 1 ]; then

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -13,7 +13,7 @@ source /etc/profile.d/python-local.sh
 # The PATH-variable depends on the host's setting. /usr/local/bin may not be included in every distro
 export PATH="${PATH}:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 
-SEAFILE_VERSION=`cat /var/lib/seafile/version`
+SEAFILE_VERSION=$(cat /var/lib/seafile/version)
 if [ -z "$SEAFILE_VERSION" ]; then
 	echo "can not find Seafile version in file /var/lib/seafile/version, probably corrupted image"
 	exit 1
@@ -116,9 +116,9 @@ if [ ! -f $VERSION_FILE ]; then
 
 	# Init seahub
 	if [ ! -f 'conf/seahub_settings.py' ]; then
-		SKEY1=`uuidgen -r`
-		SKEY2=`uuidgen -r`
-		SKEY=`echo "$SKEY1$SKEY2" | cut -c1-40`
+		SKEY1=$(uuidgen -r)
+		SKEY2=$(uuidgen -r)
+		SKEY=$(echo "$SKEY1$SKEY2" | cut -c1-40)
 		echo "SECRET_KEY = '${SKEY}'" > ${HOME}/conf/seahub_settings.py
 
 		mkdir -p seahub-data/avatars
@@ -159,7 +159,7 @@ accesslog = os.path.join(runtime_dir, 'access.log')" > "${HOME}/seafile-server/r
 else
 	# Need to check if we need to run upgrade scripts
 	echo "Version file found in container, checking it"
-	OLD_VER=`cat $VERSION_FILE`
+	OLD_VER=$(cat $VERSION_FILE)
 	if [ "x$OLD_VER" != "x$SEAFILE_VERSION" ]; then
 		echo "Version is different. Stored version is $OLD_VER, Current version is $SEAFILE_VERSION"
 		if [ -f '.no-update' ]; then
@@ -178,16 +178,16 @@ else
 			# Copy upgrade scripts. symlink doesn't work, unfortunatelly 
 			#  and I do not want to patch all of them
 			cp -rf /usr/local/share/seafile/scripts/upgrade seafile-server/
-			# Get first and second numbers of versions (we do not care about last number, actually)
-			OV1=`echo "$OLD_VER" | cut -d. -f1`
-			OV2=`echo "$OLD_VER" | cut -d. -f2`
-			CV1=`echo "$SEAFILE_VERSION" | cut -d. -f1`
-			CV2=`echo "$SEAFILE_VERSION" | cut -d. -f2`
+			# Get major and minor version number
+			OV1=$(echo "$OLD_VER" | cut -d. -f1)
+			OV2=$(echo "$OLD_VER" | cut -d. -f2)
+			CV1=$(echo "$SEAFILE_VERSION" | cut -d. -f1)
+			CV2=$(echo "$SEAFILE_VERSION" | cut -d. -f2)
 
 			i1=$OV1
 			i1p=$i1
 			i2p=$OV2
-			i2=`expr $i2p '+' 1`
+			i2=$(( $i2p + 1 ))
 			while [ $i1 -le $CV1 ]; do
 				SCRIPT="./seafile-server/upgrade/upgrade_${i1p}.${i2p}_${i1}.${i2}.sh"
 				if [ -f $SCRIPT ]; then
@@ -200,10 +200,10 @@ else
 
 					i1p=$i1
 					i2p=$i2
-					i2=`expr "$i2" '+' 1`
+					i2=$(( $i2 + 1 ))
 				else
 					i1p=$i1
-					i1=`expr "$i1" '+' 1`
+					i1=$(( $i1 + 1 ))
 					i2=0
 				fi
 			done

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -89,12 +89,9 @@ fi
 	tar xzf /usr/local/share/seafile/seahub.tgz -C seafile-server/seahub
 
 #Seafile-server related enviroment variables
-CCNET_CONF_DIR=${HOME}/ccnet
-export CCNET_CONF_DIR
-SEAFILE_CONF_DIR=${HOME}/seafile-data
-export SEAFILE_CONF_DIR
-SEAFILE_CENTRAL_CONF_DIR=${HOME}/conf
-export SEAFILE_CENTRAL_CONF_DIR
+export CCNET_CONF_DIR=${HOME}/ccnet
+export SEAFILE_CONF_DIR=${HOME}/seafile-data
+export SEAFILE_CENTRAL_CONF_DIR=${HOME}/conf
 
 #We do not want to reset admin password. probably
 RESET_ADMIN=0

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -47,7 +47,7 @@ start_seafile_server() {
 }
 
 stop_seafile() {
-	echo "SIGTERM or similar received, stopping Seafile..."
+	echo "Stopping Seafile..."
 	cd ${HOME}
 	seafile-admin stop
 	# We need to wait a bit to make sure that
@@ -234,9 +234,6 @@ fi
 echo "Starting seafile server..."
 start_seafile_server
 
-trap stop_seafile INT TERM PWR
-trap hup_seafile HUP
-
 if [ $RESET_ADMIN -eq 1 ]; then
 	# Create admin user only in interactive mode. Just becouse.
 	if [ $INTERACTIVE -eq 1 ]; then
@@ -250,14 +247,9 @@ if [ $RESET_ADMIN -eq 1 ]; then
 	echo ""
 fi
 
-if [ "x$HANDLE_SIGNALS" != "x1" ]; then
-	exec tail -f logs/* seafile-server/runtime/*.log
-else
-	#We can't run exec or our signal-handling functions will not work =(
-	tail -f logs/* seafile-server/runtime/*.log &
-	#Also we'll need to run infinity cycle I'm not sure if it's really is good idea
-	# But I have no more ides how to do it
-	while true; do
-		sleep 1
-	done
-fi
+tail -f logs/* seafile-server/runtime/*.log &
+
+trap stop_seafile INT QUIT ABRT ALRM TERM TSTP
+trap hup_seafile HUP
+
+wait

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -19,13 +19,6 @@ if [ -z "$SEAFILE_VERSION" ]; then
 	exit 1
 fi
 
-EDGE_V=`cat /var/lib/seafile/edge`
-if [ "x$EDGE_V" = "x1" ]; then
-	EDGE_V=1
-else
-	EDGE_V=0
-fi
-
 # If it is interactive run or not, by default - yes.
 # It will affect configuration and update stages
 [ -z "$INTERACTIVE" ] && INTERACTIVE=1

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -104,8 +104,6 @@ if [ ! -f $VERSION_FILE ]; then
 
 	# Init ccnet
 	if [ ! -d 'ccnet' ]; then
-		#SERVER_NAME=""
-		#SERVER_DOMAIN=""
 		if [ $INTERACTIVE -eq 1 ]; then
 			echo "Enter the name of the server  (3 - 15 letters or digits)"
 			echo -n "[server name ]: "
@@ -145,11 +143,9 @@ if [ ! -f $VERSION_FILE ]; then
 	fi
 
 	# Do syncdb anyway, because it willn't corrupt old databse
-	#if [ ! -f 'seahub.db' ]; then
 	python seafile-server/seahub/manage.py syncdb || exit 5
 	echo
 	echo '* seahub database synchronized successfully'
-	#fi
 
 	#Make Gunicorn config
 	if [ ! -f 'seafile-server/runtime/seahub.conf' ]; then
@@ -174,7 +170,7 @@ accesslog = os.path.join(runtime_dir, 'access.log')" > "${HOME}/seafile-server/r
 	#Say that we want to create admin user after server start
 	RESET_ADMIN=1
 
-else #[ ! -f $VERSION_FILE ];
+else
 	# Need to check if we need to run upgrade scripts
 	echo "Version file found in container, checking it"
 	OLD_VER=`cat $VERSION_FILE`
@@ -199,10 +195,8 @@ else #[ ! -f $VERSION_FILE ];
 			# Get first and second numbers of versions (we do not care about last number, actually)
 			OV1=`echo "$OLD_VER" | cut -d. -f1`
 			OV2=`echo "$OLD_VER" | cut -d. -f2`
-			#OV3=`echo "$OLD_VER" | cut -d. -f3`
 			CV1=`echo "$SEAFILE_VERSION" | cut -d. -f1`
 			CV2=`echo "$SEAFILE_VERSION" | cut -d. -f2`
-			#CV3=`echo "$SEAFILE_VERSION" | cut -d. -f3`
 
 			i1=$OV1
 			i1p=$i1

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -9,11 +9,9 @@ VERSION_FILE=".seafile_version"
 #Be sure, that python path variable is loaded
 source /etc/profile.d/python-local.sh   
 
-# Make sure, that /usr/local/bin is in PATH 
-# (it shoul be there and without it, 
-#  but I want to be sure, because of 
-#  all seafile utilites are in /usr/local/bin)
-PATH=${PATH}:/usr/local/bin
+# Make sure, that /usr/local/bin is in PATH
+# The PATH-variable depends on the host's setting. /usr/local/bin may not be included in every distro
+export PATH="${PATH}:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 
 SEAFILE_VERSION=`cat /var/lib/seafile/version`
 if [ -z "$SEAFILE_VERSION" ]; then


### PR DESCRIPTION
Hi @VGoshev 

Here are some internal improvements at the code. I'll continue to make PRs on your repo. I need a seafile docker container, but the official seafile container is just crap (eg. haiwen/seafile-docker#25)

Explanation of commits:

- Export PATH and inherit it to childs
    - PATH should be exported to prevent weird errors when ProgramA finds the executable, but ProgramB not.
- apk related changes:
    - split the list into multiple lines and sort the packagelist (see the [docker best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#minimize-the-number-of-layers))
    - Move the base packages into a separate layer. Although it is more common to have as less layers as possible, there are actually more pros than cons for it. (rebuild is much faster because of caching).
- Export and define variables in one line
    - Small change for readability
- Remove commented code
    - It's an anti-pattern commenting code and checking it into git, as git already has it in its history.
- the `trap KILL` is effectively dead code, as the `KILL`-signal can't get catched.
- the backticks are not neccessary and actually execute the code returned from grep. But this is not necessary, as grep states in its exit code if it had a match or not.